### PR TITLE
fix(whook-authorization): Fix parameters injection

### DIFF
--- a/packages/whook-authorization/src/__snapshots__/index.test.js.snap
+++ b/packages/whook-authorization/src/__snapshots__/index.test.js.snap
@@ -23,6 +23,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -45,6 +46,7 @@ Object {
       "🔐 - No authorization found, locking access!",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -64,6 +66,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -86,6 +89,7 @@ Object {
       "🔐 - No authorization found, locking access!",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -102,6 +106,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -120,6 +125,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -138,6 +144,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -167,6 +174,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -192,6 +200,7 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [],
 }
 `;
 
@@ -209,6 +218,86 @@ Object {
     Array [
       "debug",
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+    ],
+  ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction] {
+            "calls": Array [
+              Array [
+                "bearer",
+                Object {
+                  "hash": "yolo",
+                },
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "access_token": "yolo",
+        "authenticated": true,
+        "scopes": Array [
+          "user",
+          "admin",
+        ],
+        "userId": 1,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "security": Array [
+          Object {
+            "bearerAuth": Array [
+              "user",
+              "admin",
+            ],
+          },
+        ],
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
     ],
   ],
   "response": Object {
@@ -236,6 +325,86 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction] {
+            "calls": Array [
+              Array [
+                "bearer",
+                Object {
+                  "hash": "yolo",
+                },
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "authenticated": true,
+        "authorization": "Bearer yolo",
+        "scopes": Array [
+          "user",
+          "admin",
+        ],
+        "userId": 1,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "security": Array [
+          Object {
+            "bearerAuth": Array [
+              "user",
+              "admin",
+            ],
+          },
+        ],
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
+    ],
+  ],
   "response": Object {
     "headers": Object {
       "X-Authenticated": "{\\"userId\\":1,\\"scopes\\":[\\"user\\",\\"admin\\"]}",
@@ -259,6 +428,87 @@ Object {
     Array [
       "debug",
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+    ],
+  ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction] {
+            "calls": Array [
+              Array [
+                "bearer",
+                Object {
+                  "hash": "yolo",
+                },
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "access_token": "yolo",
+        "authenticated": true,
+        "scopes": Array [
+          "user",
+          "admin",
+        ],
+        "userId": 1,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "security": Array [
+          Object {},
+          Object {
+            "bearerAuth": Array [
+              "user",
+              "admin",
+            ],
+          },
+        ],
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
     ],
   ],
   "response": Object {
@@ -286,6 +536,87 @@ Object {
       "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
     ],
   ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction] {
+            "calls": Array [
+              Array [
+                "bearer",
+                Object {
+                  "hash": "yolo",
+                },
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": Promise {},
+              },
+            ],
+          },
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "authenticated": true,
+        "authorization": "Bearer yolo",
+        "scopes": Array [
+          "user",
+          "admin",
+        ],
+        "userId": 1,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "security": Array [
+          Object {},
+          Object {
+            "bearerAuth": Array [
+              "user",
+              "admin",
+            ],
+          },
+        ],
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
+    ],
+  ],
   "response": Object {
     "headers": Object {
       "X-Authenticated": "{\\"userId\\":1,\\"scopes\\":[\\"user\\",\\"admin\\"]}",
@@ -308,6 +639,74 @@ Object {
       "🔓 - Optionally authenticated enpoint detected, letting the call pass through!",
     ],
   ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction],
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+            Array [
+              "debug",
+              "🔓 - Optionally authenticated enpoint detected, letting the call pass through!",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "authenticated": false,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "security": Array [
+          Object {},
+          Object {
+            "bearerAuth": Array [
+              "user",
+              "admin",
+            ],
+          },
+        ],
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
+    ],
+  ],
   "response": Object {
     "status": 200,
   },
@@ -325,6 +724,65 @@ Object {
     Array [
       "debug",
       "🔓 - Public endpoint detected, letting the call pass through!",
+    ],
+  ],
+  "noopMockCalls": Array [
+    Array [
+      Object {
+        "DEFAULT_MECHANISM": "Bearer",
+        "MECHANISMS": Array [
+          Object {
+            "buildAuthorizationRest": [Function],
+            "buildWWWAuthenticateRest": [Function],
+            "parseAuthorizationRest": [Function],
+            "parseWWWAuthenticateRest": [Function],
+            "type": "Bearer",
+          },
+        ],
+        "authentication": Object {
+          "check": [MockFunction],
+        },
+        "log": [MockFunction] {
+          "calls": Array [
+            Array [
+              "debug",
+              "🔐 - Initializing the authorization wrapper for \\"getNoop\\".",
+            ],
+            Array [
+              "debug",
+              "🔓 - Public endpoint detected, letting the call pass through!",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        },
+      },
+      Object {
+        "aParameter": 1,
+        "authenticated": false,
+      },
+      Object {
+        "consumes": Array [],
+        "operationId": "noopHandler",
+        "produces": Array [],
+        "responses": Object {
+          "200": Object {
+            "description": "Sucessfully did nothing!",
+          },
+        },
+        "summary": "Does nothing.",
+        "tags": Array [
+          "system",
+        ],
+      },
     ],
   ],
   "response": Object {

--- a/packages/whook-authorization/src/index.js
+++ b/packages/whook-authorization/src/index.js
@@ -86,7 +86,10 @@ async function handleWithAuthorization(
         ? '🔓 - Public endpoint detected, letting the call pass through!'
         : '🔓 - Optionally authenticated enpoint detected, letting the call pass through!',
     );
-    response = await handler({ parameters, authenticated: false }, operation);
+    response = await handler(
+      { ...parameters, authenticated: false },
+      operation,
+    );
   } else {
     let parsedAuthorization;
 

--- a/packages/whook-authorization/src/index.test.js
+++ b/packages/whook-authorization/src/index.test.js
@@ -11,6 +11,7 @@ describe('wrapHandlerWithAuthorization', () => {
   const authentication = {
     check: jest.fn(),
   };
+  const noopMock = jest.fn(() => ({ status: 200 }));
   const NOOP_OPERATION = {
     operationId: 'noopHandler',
     summary: 'Does nothing.',
@@ -50,13 +51,14 @@ describe('wrapHandlerWithAuthorization', () => {
   };
 
   beforeEach(() => {
+    noopMock.mockClear();
     log.mockReset();
     authentication.check.mockReset();
   });
 
   describe('with unauthenticated endpoints', () => {
     it('should work', async () => {
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -64,10 +66,11 @@ describe('wrapHandlerWithAuthorization', () => {
         authentication,
         log,
       });
-      const response = await wrappedHandler({}, NOOP_OPERATION);
+      const response = await wrappedHandler({ aParameter: 1 }, NOOP_OPERATION);
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -80,7 +83,7 @@ describe('wrapHandlerWithAuthorization', () => {
         userId: 1,
         scopes: ['user', 'admin'],
       });
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -91,12 +94,14 @@ describe('wrapHandlerWithAuthorization', () => {
       const response = await wrappedHandler(
         {
           authorization: 'Bearer yolo',
+          aParameter: 1,
         },
         NOOP_AUTHENTICATED_OPERATION,
       );
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -107,7 +112,7 @@ describe('wrapHandlerWithAuthorization', () => {
         userId: 1,
         scopes: ['user', 'admin'],
       });
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -118,12 +123,14 @@ describe('wrapHandlerWithAuthorization', () => {
       const response = await wrappedHandler(
         {
           access_token: 'yolo',
+          aParameter: 1,
         },
         NOOP_AUTHENTICATED_OPERATION,
       );
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -134,7 +141,7 @@ describe('wrapHandlerWithAuthorization', () => {
         userId: 1,
         scopes: ['user', 'admin'],
       });
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -142,10 +149,14 @@ describe('wrapHandlerWithAuthorization', () => {
         authentication,
         log,
       });
-      const response = await wrappedHandler({}, NOOP_AUTHENTICATED_OPERATION);
+      const response = await wrappedHandler(
+        { aParameter: 1 },
+        NOOP_AUTHENTICATED_OPERATION,
+      );
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -158,7 +169,7 @@ describe('wrapHandlerWithAuthorization', () => {
         userId: 1,
         scopes: ['user', 'admin'],
       });
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -169,12 +180,14 @@ describe('wrapHandlerWithAuthorization', () => {
       const response = await wrappedHandler(
         {
           authorization: 'Bearer yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -185,7 +198,7 @@ describe('wrapHandlerWithAuthorization', () => {
         userId: 1,
         scopes: ['user', 'admin'],
       });
-      const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+      const noopHandler = handler(noopMock, 'getNoop');
       const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
         noopHandler,
       );
@@ -196,12 +209,14 @@ describe('wrapHandlerWithAuthorization', () => {
       const response = await wrappedHandler(
         {
           access_token: 'yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
 
       expect({
         response,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -209,7 +224,7 @@ describe('wrapHandlerWithAuthorization', () => {
   });
 
   it('should fail with no operation definition provided', async () => {
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -229,6 +244,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -240,7 +256,7 @@ describe('wrapHandlerWithAuthorization', () => {
       userId: 1,
       scopes: ['user', 'admin'],
     });
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -254,6 +270,7 @@ describe('wrapHandlerWithAuthorization', () => {
         {
           access_token: 'yolo',
           userId: 3,
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -264,6 +281,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -271,7 +289,7 @@ describe('wrapHandlerWithAuthorization', () => {
   });
 
   it('should fail with bad operation definition provided', async () => {
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -284,6 +302,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           access_token: 'yolo',
+          aParameter: 1,
         },
         BAD_OPERATION,
       );
@@ -294,6 +313,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -305,7 +325,7 @@ describe('wrapHandlerWithAuthorization', () => {
       userId: 1,
       scopes: [],
     });
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -318,6 +338,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           authorization: 'Bearer yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -328,6 +349,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -339,7 +361,7 @@ describe('wrapHandlerWithAuthorization', () => {
       userId: 1,
       scopes: [],
     });
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -353,6 +375,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           authorization: 'Basic yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -363,6 +386,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -374,7 +398,7 @@ describe('wrapHandlerWithAuthorization', () => {
       new YError('E_UNEXPECTED_TOKEN_CHECK'),
     );
 
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -387,6 +411,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           authorization: 'Whatever yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -397,6 +422,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -408,7 +434,7 @@ describe('wrapHandlerWithAuthorization', () => {
       new YError('E_UNEXPECTED_TOKEN_CHECK'),
     );
 
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -418,7 +444,7 @@ describe('wrapHandlerWithAuthorization', () => {
     });
 
     try {
-      await wrappedHandler({}, NOOP_RESTRICTED_OPERATION);
+      await wrappedHandler({ aParameter: 1 }, NOOP_RESTRICTED_OPERATION);
       throw new YError('E_UNEXPECTED_SUCCESS');
     } catch (err) {
       expect({
@@ -426,6 +452,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -437,7 +464,7 @@ describe('wrapHandlerWithAuthorization', () => {
       new YError('E_UNEXPECTED_TOKEN_CHECK'),
     );
 
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -451,6 +478,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           access_token: 'yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -461,6 +489,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();
@@ -474,7 +503,7 @@ describe('wrapHandlerWithAuthorization', () => {
 
     authentication.check.mockRejectedValue(new YError('E_UNAUTHORIZED'));
 
-    const noopHandler = handler(() => ({ status: 200 }), 'getNoop');
+    const noopHandler = handler(noopMock, 'getNoop');
     const wrappedNoodHandlerWithAuthorization = wrapHandlerWithAuthorization(
       noopHandler,
     );
@@ -487,6 +516,7 @@ describe('wrapHandlerWithAuthorization', () => {
       await wrappedHandler(
         {
           authorization: 'Bearer yolo',
+          aParameter: 1,
         },
         NOOP_RESTRICTED_OPERATION,
       );
@@ -497,6 +527,7 @@ describe('wrapHandlerWithAuthorization', () => {
         errorCode: err.code,
         errorParams: err.params,
         errorHeaders: err.headers,
+        noopMockCalls: noopMock.mock.calls,
         authenticationChecks: authentication.check.mock.calls,
         logCalls: log.mock.calls.filter(args => 'stack' !== args[0]),
       }).toMatchSnapshot();


### PR DESCRIPTION
The parameters where badly injected when using `whook-authorization`. This commit fixes this problem and adds non regression tests.