### PR TITLE
feat(swaggerui): add mutedParameters option

### DIFF
--- a/packages/whook-swagger-ui/src/handlers/__snapshots__/getOpenAPI.test.ts.snap
+++ b/packages/whook-swagger-ui/src/handlers/__snapshots__/getOpenAPI.test.ts.snap
@@ -8,7 +8,7 @@ Object {
         "title": "test",
         "version": "<already_tested>",
       },
-      "openapi": "2.0",
+      "openapi": "3.0.0",
       "paths": Object {
         "/time": Object {
           "get": Object {
@@ -52,10 +52,57 @@ Object {
         "title": "test",
         "version": "<already_tested>",
       },
-      "openapi": "2.0",
+      "openapi": "3.0.0",
       "paths": Object {
         "/time": Object {
           "get": Object {
+            "tags": Array [
+              "public",
+            ],
+            "x-whook": undefined,
+          },
+        },
+      },
+      "tags": Array [
+        Object {
+          "name": "public",
+        },
+        Object {
+          "name": "private",
+        },
+      ],
+    },
+    "status": 200,
+  },
+}
+`;
+
+exports[`getOpenAPI should work with muted paramerter 1`] = `
+Object {
+  "response": Object {
+    "body": Object {
+      "components": Object {
+        "parameters": Object {
+          "xRefToRemove": Object {
+            "in": "header",
+            "name": "X-Ref-To-Remove",
+          },
+        },
+      },
+      "info": Object {
+        "title": "test",
+        "version": "<already_tested>",
+      },
+      "openapi": "3.0.0",
+      "paths": Object {
+        "/time": Object {
+          "get": Object {
+            "parameters": Array [
+              Object {
+                "in": "query",
+                "name": "queryParam",
+              },
+            ],
             "tags": Array [
               "public",
             ],

--- a/packages/whook-swagger-ui/src/handlers/getOpenAPI.test.ts
+++ b/packages/whook-swagger-ui/src/handlers/getOpenAPI.test.ts
@@ -2,7 +2,7 @@ import initGetOpenAPI from './getOpenAPI';
 
 describe('getOpenAPI', () => {
   const API = {
-    openapi: '2.0',
+    openapi: '3.0.0',
     info: {
       title: 'test',
       version: '1',
@@ -20,6 +20,50 @@ describe('getOpenAPI', () => {
         put: {
           tags: ['private'],
           'x-whook': { private: true },
+        },
+      },
+    },
+    tags: [{ name: 'public' }, { name: 'private' }],
+  };
+
+  const APIWithParameters = {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '1',
+    },
+    paths: {
+      '/time': {
+        options: {
+          tags: ['public'],
+          'x-whook': { memx: 2, tx: 18 },
+        },
+        get: {
+          tags: ['public'],
+          'x-whook': { memx: 2, tx: 18 },
+          parameters: [
+            {
+              in: 'query',
+              name: 'queryParam',
+            },
+            {
+              in: 'query',
+              name: 'parameterToRemove',
+            },
+            { $ref: '#/components/parameters/xRefToRemove' },
+          ],
+        },
+        put: {
+          tags: ['private'],
+          'x-whook': { private: true },
+        },
+      },
+    },
+    components: {
+      parameters: {
+        xRefToRemove: {
+          name: 'X-Ref-To-Remove',
+          in: 'header',
         },
       },
     },
@@ -52,6 +96,28 @@ describe('getOpenAPI', () => {
     });
     const response = await getOpenAPI({
       authenticated: true,
+    });
+
+    expect({
+      response: {
+        ...response,
+        body: {
+          ...response.body,
+          info: {
+            ...response.body.info,
+            version: '<already_tested>',
+          },
+        },
+      },
+    }).toMatchSnapshot();
+  });
+
+  it('should work with muted paramerter', async () => {
+    const getOpenAPI = await initGetOpenAPI({
+      API: APIWithParameters,
+    });
+    const response = await getOpenAPI({
+      mutedParameters: ['X-Ref-To-Remove', 'parameterToRemove'],
     });
 
     expect({


### PR DESCRIPTION
This PR allows to send an array (like mutedMethods) to remove some parameters from the openAPI definition (for example some header used for debug)