### PR TITLE
chore(deps): upgrade whook as peerDep

### DIFF
--- a/packages/whook-http-router/package.json
+++ b/packages/whook-http-router/package.json
@@ -74,7 +74,7 @@
     "yhttperror": "^5.0.0"
   },
   "peerDependencies": {
-    "@whook/whook": "^4.0.0"
+    "@whook/whook": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/packages/whook-http-server/package.json
+++ b/packages/whook-http-server/package.json
@@ -60,7 +60,7 @@
     "yerror": "^5.0.0"
   },
   "peerDependencies": {
-    "@whook/whook": "^4.0.0"
+    "@whook/whook": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/packages/whook-http-transaction/package.json
+++ b/packages/whook-http-transaction/package.json
@@ -64,7 +64,7 @@
     "yhttperror": "^5.0.0"
   },
   "peerDependencies": {
-    "@whook/whook": "^4.0.0"
+    "@whook/whook": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
Getting warnings when installing latest version of whook cause some peerDependencies are not up-to-date