### PR TITLE
feat(types): allow types overriding

### DIFF
--- a/packages/whook-authorization/README.md
+++ b/packages/whook-authorization/README.md
@@ -110,28 +110,43 @@ async function initWrappers(): Promise<WhookWrapper<any, any>[]> {
 }
 ```
 
+Declare this module types in your `src/whook.d.ts` type
+ definitions:
+```diff
++ import type { WhookAuthorizationConfig } from '@whook/authorization';
+
+declare module '@whook/whook' {
+
+  // ...
+
+  export interface WhookConfigs
+-    extends WhookBaseConfigs {}
++    extends WhookBaseConfigs, WhookAuthorizationConfig {}
+
+  // ...
+
+}
+```
+
 Then add the config and the errors descriptors or provide your
  own (usually in `src/config/common/config.js`):
 ```diff
 import { DEFAULT_ERRORS_DESCRIPTORS } from '@whook/http-router';
 + import {
 +   AUTHORIZATION_ERRORS_DESCRIPTORS,
-+   WhookAuthorizationConfig
 + } from '@whook/authorization';
+import type { WhookConfigs } from '@whook/whook';
 
 // ...
 
-export type AppConfigs = WhookConfigs &
-+  WhookAuthorizationConfig &
-  APIConfig;
-
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   // ...
 -   ERRORS_DESCRIPTORS: DEFAULT_ERRORS_DESCRIPTORS,
 +   ERRORS_DESCRIPTORS: {
 +     ...DEFAULT_ERRORS_DESCRIPTORS,
 +     ...AUTHORIZATION_ERRORS_DESCRIPTORS,
 +   },
++   DEFAULT_MECHANISM: 'bearer',
   // ...
 };
 

--- a/packages/whook-aws-lambda/README.md
+++ b/packages/whook-aws-lambda/README.md
@@ -108,34 +108,56 @@ export async function prepareBuildEnvironment(
 }
 ```
 
-And add the AWS Lambda config (usually in `src/config/common/config.js`):
-
+Declare this module types in your `src/whook.d.ts` type
+ definitions:
 ```diff
 + import type { WhookCompilerConfig } from '@whook/whook';
 + import type {
-+   WhookAPIOperationGCPFunctionConfig
++   WhookAPIOperationAWSLambdaConfig
 + } from '@whook/aws-lambda';
+
+declare module '@whook/whook' {
+
+  // ...
+
+  export interface WhookConfigs
+-    extends WhookBaseConfigs {}
++    extends WhookBaseConfigs, WhookCompilerConfig {}
+
+  // ...
+
+  export interface WhookAPIHandlerDefinition<
+    T extends Record<string, unknown> = Record<string, unknown>,
+    U extends {
+      [K in keyof U]: K extends `x-${string}` ? Record<string, unknown> : never;
+    } = unknown,
+  > extends WhookBaseAPIHandlerDefinition<T, U> {
+    operation: U & WhookAPIOperation<
+        T &
++       WhookAPIOperationAWSLambdaConfig<{
++         myCronBodyProp: string,
++       }> &
+      WhookAPIOperationCORSConfig
+    >;
+  }
+
+}
+```
+
+And add the AWS Lambda config (usually in `src/config/common/config.js`):
+
+```diff
+import type { WhookConfigs } from '@whook/whook';
 
 // ...
 
-export type AppConfigs = WhookConfigs &
-+  WhookCompilerConfig &
-  APIConfig;
-
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   // ...
 +  COMPILER_OPTIONS: {
 +    externalModules: [],
-+    ignoredModules: [],
 +    target: '14',
 +  },
 };
-
-// Export custom handlers definitions
-export type APIHandlerDefinition = WhookAPIHandlerDefinition<
-+  WhookAPIOperationAWSLambdaConfig &
-  WhookAPIOperationSwaggerConfig
->;
 
 export default CONFIG;
 ```

--- a/packages/whook-example/src/config/common/config.ts
+++ b/packages/whook-example/src/config/common/config.ts
@@ -1,13 +1,5 @@
 import { DEFAULT_ERRORS_DESCRIPTORS } from '@whook/http-router';
-import type { WhookAuthorizationConfig } from '@whook/authorization';
-import type {
-  WhookAPIOperationSwaggerConfig,
-  WhookSwaggerUIConfig,
-} from '@whook/swagger-ui';
-import type { WhookAPIOperationCORSConfig, WhookCORSConfig } from '@whook/cors';
-import type { WhookAPIHandlerDefinition, WhookConfigs } from '@whook/whook';
-import type { APIConfig } from '../../services/API';
-import type { JWTServiceConfig } from 'jwt-service';
+import type { WhookConfigs } from '@whook/whook';
 
 /* Architecture Note #2: Configuration
 
@@ -23,28 +15,6 @@ const packageConf = require('../../../package');
 const DEBUG_NODE_ENVS = ['test', 'development', 'staging'];
 const NODE_ENVS = [...DEBUG_NODE_ENVS, 'uat', 'production'];
 
-/* Architecture Note #2.1: Typings
-
-The configuration is typed so that you are sure you cannot
- produce a bad configuration for your API.
-*/
-export type AppConfigs = WhookConfigs &
-  WhookAuthorizationConfig &
-  WhookSwaggerUIConfig &
-  WhookCORSConfig &
-  APIConfig &
-  JWTServiceConfig;
-
-/* Architecture Note #3.2.3: Typings
-
-Here we export a custom handler definition type in order
- to allow using the various plugins installed that deal
- with the handlers.
-*/
-export type APIHandlerDefinition = WhookAPIHandlerDefinition<
-  WhookAPIOperationCORSConfig & WhookAPIOperationSwaggerConfig
->;
-
 /* Architecture Note #2.2: Exporting
 
 Each configuration file then create a configuration object
@@ -52,11 +22,10 @@ Each configuration file then create a configuration object
 
 See the [Whook Config Service](https://github.com/nfroidure/whook/blob/7dce55291a81628a0e95a07ce1e978a276b99578/packages/whook/src/services/CONFIGS.ts#L56).
 */
-const CONFIG: AppConfigs = {
+const CONFIG: Omit<WhookConfigs, 'HOST'> = {
   BASE_ENV: {},
   API_VERSION: packageConf.version,
   BASE_PATH: `/v${packageConf.version.split('.')[0]}`,
-  HOST: 'localhost',
   CONFIG: {
     name: packageConf.name,
     description: packageConf.description || '',

--- a/packages/whook-example/src/config/development/config.ts
+++ b/packages/whook-example/src/config/development/config.ts
@@ -1,5 +1,5 @@
 import COMMON_CONFIG from '../common/config';
-import type { AppConfigs } from '../common/config';
+import type { WhookConfigs } from '@whook/whook';
 
 /* Architecture Note #2.3: Overriding
 
@@ -7,8 +7,9 @@ Finally the configuration file for a given environnment
  may reuse or override the custom configuration file
  like here for the development configuration.
 */
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   ...COMMON_CONFIG,
+  HOST: 'localhost',
   DEV_ACCESS_TOKEN: 'admin|1|1',
   DEFAULT_MECHANISM: 'Fake',
   // This allows you to map service names depending on

--- a/packages/whook-example/src/config/production/config.ts
+++ b/packages/whook-example/src/config/production/config.ts
@@ -1,8 +1,9 @@
 import COMMON_CONFIG from '../common/config';
-import type { AppConfigs } from '../common/config';
+import type { WhookConfigs } from '@whook/whook';
 
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   ...COMMON_CONFIG,
+  HOST: 'api.example.com',
 };
 
 export default CONFIG;

--- a/packages/whook-example/src/config/staging/config.ts
+++ b/packages/whook-example/src/config/staging/config.ts
@@ -1,8 +1,9 @@
 import COMMON_CONFIG from '../common/config';
-import type { AppConfigs } from '../common/config';
+import type { WhookConfigs } from '@whook/whook';
 
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   ...COMMON_CONFIG,
+  HOST: 'staging.example.com',
 };
 
 export default CONFIG;

--- a/packages/whook-example/src/config/test/config.ts
+++ b/packages/whook-example/src/config/test/config.ts
@@ -1,8 +1,9 @@
 import COMMON_CONFIG from '../common/config';
-import type { AppConfigs } from '../common/config';
+import type { WhookConfigs } from '@whook/whook';
 
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   ...COMMON_CONFIG,
+  HOST: 'localhost',
 };
 
 export default CONFIG;

--- a/packages/whook-example/src/config/uat/config.ts
+++ b/packages/whook-example/src/config/uat/config.ts
@@ -1,8 +1,9 @@
 import COMMON_CONFIG from '../common/config';
-import type { AppConfigs } from '../common/config';
+import type { WhookConfigs } from '@whook/whook';
 
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   ...COMMON_CONFIG,
+  HOST: 'uat.example.com',
 };
 
 export default CONFIG;

--- a/packages/whook-example/src/handlers/getDelay.ts
+++ b/packages/whook-example/src/handlers/getDelay.ts
@@ -1,7 +1,9 @@
 import { autoHandler } from 'knifecycle';
 import { refersTo } from '@whook/whook';
-import type { WhookAPIParameterDefinition } from '@whook/whook';
-import type { APIHandlerDefinition } from '../config/common/config';
+import type {
+  WhookAPIParameterDefinition,
+  WhookAPIHandlerDefinition,
+} from '@whook/whook';
 import type { DelayService } from 'common-services';
 
 /* Architecture Note #3.4: Examples
@@ -45,7 +47,7 @@ For it to work, you have to export the definition, like
  here, to make it available for the API service, responsible
  for gathering all API route definitions.
 */
-export const definition: APIHandlerDefinition = {
+export const definition: WhookAPIHandlerDefinition = {
   path: '/delay',
   method: 'get',
   operation: {

--- a/packages/whook-example/src/handlers/getDiagnostic.ts
+++ b/packages/whook-example/src/handlers/getDiagnostic.ts
@@ -1,7 +1,9 @@
 import { refersTo } from '@whook/whook';
 import { autoHandler } from 'knifecycle';
-import type { WhookAPIResponseDefinition } from '@whook/whook';
-import type { APIHandlerDefinition } from '../config/common/config';
+import type {
+  WhookAPIResponseDefinition,
+  WhookAPIHandlerDefinition,
+} from '@whook/whook';
 
 export const diagnosticResponse: WhookAPIResponseDefinition = {
   name: 'Diagnostic',
@@ -29,7 +31,7 @@ export const diagnosticResponse: WhookAPIResponseDefinition = {
 Here is a simple handler that just proxy the `TRANSACTIONS`
  service which contains the currently pending transactions.
 */
-export const definition: APIHandlerDefinition = {
+export const definition: WhookAPIHandlerDefinition = {
   path: '/diagnostic',
   method: 'get',
   operation: {

--- a/packages/whook-example/src/handlers/getParameters.ts
+++ b/packages/whook-example/src/handlers/getParameters.ts
@@ -1,7 +1,9 @@
 import { autoHandler } from 'knifecycle';
 import { refersTo } from '@whook/whook';
-import type { WhookAPIParameterDefinition } from '@whook/whook';
-import type { APIHandlerDefinition } from '../config/common/config';
+import type {
+  WhookAPIParameterDefinition,
+  WhookAPIHandlerDefinition,
+} from '@whook/whook';
 
 export const pathParam1Parameter: WhookAPIParameterDefinition<API.GetParameters.Parameters.PathParam1> =
   {
@@ -40,7 +42,7 @@ export const pathParam2Parameter: WhookAPIParameterDefinition<API.GetParameters.
 Here is a simple handler that just proxy the `TRANSACTIONS`
  service which contains the currently pending transactions.
 */
-export const definition: APIHandlerDefinition = {
+export const definition: WhookAPIHandlerDefinition = {
   path: `/{${pathParam1Parameter.parameter.name}}/{${pathParam2Parameter.parameter.name}}`,
   method: 'get',
   operation: {

--- a/packages/whook-example/src/handlers/getTime.ts
+++ b/packages/whook-example/src/handlers/getTime.ts
@@ -1,7 +1,9 @@
 import { autoHandler } from 'knifecycle';
 import { refersTo } from '@whook/whook';
-import type { WhookAPISchemaDefinition } from '@whook/whook';
-import type { APIHandlerDefinition } from '../config/common/config';
+import type {
+  WhookAPISchemaDefinition,
+  WhookAPIHandlerDefinition,
+} from '@whook/whook';
 import type { TimeService } from 'common-services';
 
 export const timeSchema: WhookAPISchemaDefinition<Components.Schemas.TimeSchema> =
@@ -23,7 +25,7 @@ export const timeSchema: WhookAPISchemaDefinition<Components.Schemas.TimeSchema>
 
 Returns the server time.
 */
-export const definition: APIHandlerDefinition = {
+export const definition: WhookAPIHandlerDefinition = {
   path: '/time',
   method: 'get',
   operation: {

--- a/packages/whook-example/src/handlers/putEcho.ts
+++ b/packages/whook-example/src/handlers/putEcho.ts
@@ -6,8 +6,8 @@ import type {
   WhookAPISchemaDefinition,
   WhookAPIResponseDefinition,
   WhookAPIRequestBodyDefinition,
+  WhookAPIHandlerDefinition,
 } from '@whook/whook';
-import type { APIHandlerDefinition } from '../config/common/config';
 
 /* Architecture Note #3.1.3: Reusable schemas
 
@@ -87,7 +87,7 @@ export const echoRequestBody: WhookAPIRequestBodyDefinition = {
 
 Simply outputs its input.
 */
-export const definition: APIHandlerDefinition = {
+export const definition: WhookAPIHandlerDefinition = {
   path: '/echo',
   method: 'put',
   operation: {

--- a/packages/whook-example/src/services/API.ts
+++ b/packages/whook-example/src/services/API.ts
@@ -9,7 +9,6 @@ export type APIEnv = {
   DEV_MODE?: string;
 };
 export type APIConfig = {
-  ENV?: APIEnv;
   CONFIG: WhookConfig;
   BASE_URL?: string;
   BASE_PATH?: string;

--- a/packages/whook-example/src/whook.d.ts
+++ b/packages/whook-example/src/whook.d.ts
@@ -1,0 +1,51 @@
+import type {
+  WhookBaseAPIHandlerDefinition,
+  WhookBaseEnv,
+  WhookBaseConfigs,
+  WhookAPIOperation,
+} from '@whook/whook';
+import type { WhookAuthorizationConfig } from '@whook/authorization';
+import type {
+  WhookAPIOperationSwaggerConfig,
+  WhookSwaggerUIConfig,
+  WhookSwaggerUIEnv,
+} from '@whook/swagger-ui';
+import type { WhookAPIOperationCORSConfig, WhookCORSConfig } from '@whook/cors';
+import type { APIConfig } from './services/API';
+import type { JWTServiceConfig } from 'jwt-service';
+
+declare module '@whook/whook' {
+  // Eventually override the process env type here
+  export interface WhookEnv extends WhookBaseEnv, WhookSwaggerUIEnv {}
+
+  /* Architecture Note #2.1: Typings
+
+The configuration is typed so that you are sure you cannot
+ produce a bad configuration for your API.
+*/
+  export interface WhookConfigs
+    extends WhookBaseConfigs,
+      WhookAuthorizationConfig,
+      WhookSwaggerUIConfig,
+      WhookCORSConfig,
+      APIConfig,
+      JWTServiceConfig {}
+
+  /* Architecture Note #3.2.3: Typings
+
+Here we export a custom handler definition type in order
+ to allow using the various plugins installed that deal
+ with the handlers.
+*/
+  export interface WhookAPIHandlerDefinition<
+    T extends Record<string, unknown> = Record<string, unknown>,
+    U extends {
+      [K in keyof U]: K extends `x-${string}` ? Record<string, unknown> : never;
+    } = unknown,
+  > extends WhookBaseAPIHandlerDefinition<T, U> {
+    operation: U &
+      WhookAPIOperation<
+        T & WhookAPIOperationSwaggerConfig & WhookAPIOperationCORSConfig
+      >;
+  }
+}

--- a/packages/whook-graphiql/src/index.ts
+++ b/packages/whook-graphiql/src/index.ts
@@ -22,7 +22,7 @@ export type WhookGraphIQLOptions = {
 export type WhookGraphIQLConfig = {
   DEV_ACCESS_TOKEN?: string;
   DEV_ACCESS_MECHANISM?: string;
-  BASE_PATH: string;
+  BASE_PATH?: string;
   HOST?: string;
   PORT?: number;
   GRAPHIQL?: WhookGraphIQLOptions;
@@ -51,7 +51,7 @@ export default function wrapHTTPRouterWithGraphIQL<D>(
     [
       '?DEV_ACCESS_TOKEN',
       '?DEV_ACCESS_MECHANISM',
-      'BASE_PATH',
+      '?BASE_PATH',
       'HOST',
       'PORT',
       '?GRAPHIQL',
@@ -66,7 +66,7 @@ export default function wrapHTTPRouterWithGraphIQL<D>(
       {
         DEV_ACCESS_TOKEN = '',
         DEV_ACCESS_MECHANISM = 'Bearer',
-        BASE_PATH,
+        BASE_PATH = '',
         HOST,
         PORT,
         GRAPHIQL = DEFAULT_GRAPHIQL,

--- a/packages/whook-http-router/src/index.ts
+++ b/packages/whook-http-router/src/index.ts
@@ -153,7 +153,7 @@ export type HTTPRouterConfig = {
   NODE_ENV?: string;
   DEBUG_NODE_ENVS?: string[];
   BUFFER_LIMIT?: string;
-  BASE_PATH: string;
+  BASE_PATH?: string;
 };
 export type HTTPRouterDependencies = HTTPRouterConfig & {
   NODE_ENV: string;
@@ -209,7 +209,7 @@ export default initializer(
       'NODE_ENV',
       '?DEBUG_NODE_ENVS',
       '?BUFFER_LIMIT',
-      'BASE_PATH',
+      '?BASE_PATH',
       'HANDLERS',
       'API',
       '?PARSERS',
@@ -269,7 +269,7 @@ async function initHTTPRouter({
   NODE_ENV,
   DEBUG_NODE_ENVS = DEFAULT_DEBUG_NODE_ENVS,
   BUFFER_LIMIT = DEFAULT_BUFFER_LIMIT,
-  BASE_PATH,
+  BASE_PATH = '',
   HANDLERS,
   API,
   PARSERS = DEFAULT_PARSERS,
@@ -535,13 +535,13 @@ function _explodePath(path, parameters) {
 async function _createRouters({
   API,
   HANDLERS,
-  BASE_PATH,
+  BASE_PATH = '',
   ajv,
   log,
 }: {
   API: OpenAPIV3.Document;
   HANDLERS: WhookHandlers;
-  BASE_PATH: string;
+  BASE_PATH?: string;
   ajv: Ajv;
   log: LogService;
 }): Promise<{ [method: string]: Siso<RouteDescriptor> }> {
@@ -596,7 +596,7 @@ async function _createRouters({
 
     routers[method] = routers[method] || new Siso();
     routers[method].register(
-      _explodePath((BASE_PATH || '') + path, pathParameters),
+      _explodePath(BASE_PATH + path, pathParameters),
       _prepareRoute({ ajv }, operation, handler, ammendedParameters),
     );
   });

--- a/packages/whook-oauth2/README.md
+++ b/packages/whook-oauth2/README.md
@@ -61,6 +61,24 @@ Declare the plugin into your `index.ts` file:
   // (...)
 ```
 
+Declare this module types in your `src/whook.d.ts` type
+ definitions:
+```diff
++ import type { OAuth2Config } from '@whook/oauth2';
+
+declare module '@whook/whook' {
+
+  // ...
+
+  export interface WhookConfigs
+-    extends WhookBaseConfigs {}
++    extends WhookBaseConfigs, OAuth2Config {}
+
+  // ...
+
+}
+```
+
 Add the OAuth2 configuration to your config files:
 
 ```diff
@@ -68,14 +86,11 @@ Add the OAuth2 configuration to your config files:
 +   OAUTH2_ERRORS_DESCRIPTORS,
 +   OAuth2Config,
 + } from '@whook/oauth2';
+import type { WhookConfigs } from '@whook/whook';
 
 // ...
 
-export type AppConfigs = WhookConfigs &
-+  OAuth2Config &
-  APIConfig;
-
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   // ...
 +   OAUTH2: {
 +     // The SSR frontend

--- a/packages/whook-oauth2/src/handlers/postOAuth2Acknowledge.ts
+++ b/packages/whook-oauth2/src/handlers/postOAuth2Acknowledge.ts
@@ -28,7 +28,7 @@ export const definition: WhookAPIHandlerDefinition = {
     tags: ['oauth2'],
     'x-whook': {
       private: true,
-    } as WhookAPIOperationConfig,
+    },
     requestBody: {
       required: true,
       content: {

--- a/packages/whook-swagger-ui/README.md
+++ b/packages/whook-swagger-ui/README.md
@@ -54,29 +54,49 @@ export async function runServer(injectedNames = [], $ = new Knifecycle()) {
 }
 ```
 
-And add the SwaggerUI config (usually in `src/config/common/config.js`):
+Declare this module types in your `src/whook.d.ts` type
+ definitions:
 ```diff
 + import type {
 +   WhookAPIOperationSwaggerConfig,
 +   WhookSwaggerUIConfig,
 + } from '@whook/swagger-ui';
 
-// ...
+declare module '@whook/whook' {
 
-export type AppConfigs = WhookConfigs &
-  CORSConfig &
-+  WhookSwaggerUIConfig &
-  APIConfig;
-
-const CONFIG: AppConfigs = {
   // ...
+
+  export interface WhookConfigs
+-    extends WhookBaseConfigs {}
++    extends WhookBaseConfigs, WhookSwaggerUIConfig {}
+
+  // ...
+
+  export interface WhookAPIHandlerDefinition<
+    T extends Record<string, unknown> = Record<string, unknown>,
+    U extends {
+      [K in keyof U]: K extends `x-${string}` ? Record<string, unknown> : never;
+    } = unknown,
+  > extends WhookBaseAPIHandlerDefinition<T, U> {
+    operation: U & WhookAPIOperation<
+        T &
++      WhookAPIOperationSwaggerConfig &
+      WhookAPIOperationCORSConfig
+    >;
+  }
+
+}
+```
+
+And add the SwaggerUI config (usually in `src/config/common/config.js`):
+```diff
+import type { WhookConfigs } from '@whook/whook';
+
+const CONFIG: WhookConfigs = {
+  // ...
+  BASE_PATH: 'v4',
 };
 
-// Export custom handlers definitions
-export type APIHandlerDefinition = WhookAPIHandlerDefinition<
-  WhookAPIOperationCORSConfig &
-+  WhookAPIOperationSwaggerConfig
->;
 
 export default CONFIG;
 ```

--- a/packages/whook-swagger-ui/src/index.ts
+++ b/packages/whook-swagger-ui/src/index.ts
@@ -18,7 +18,7 @@ export type WhookSwaggerUIEnv = {
 };
 export type WhookSwaggerUIConfig = {
   DEV_ACCESS_TOKEN?: string;
-  BASE_PATH: string;
+  BASE_PATH?: string;
   HOST?: string;
   PORT?: number;
 };
@@ -51,7 +51,7 @@ export default function wrapHTTPRouterWithSwaggerUI<D>(
     [
       'ENV',
       '?DEV_ACCESS_TOKEN',
-      'BASE_PATH',
+      '?BASE_PATH',
       'HOST',
       'PORT',
       'importer',
@@ -65,7 +65,7 @@ export default function wrapHTTPRouterWithSwaggerUI<D>(
       {
         ENV,
         DEV_ACCESS_TOKEN,
-        BASE_PATH,
+        BASE_PATH = '',
         HOST,
         PORT,
         log = noop,

--- a/packages/whook-versions/README.md
+++ b/packages/whook-versions/README.md
@@ -33,14 +33,31 @@ async function initWrappers(): Promise<WhookWrapper<any, any>[]> {
 }
 ```
 
-And add the versions config and the errors descriptors or provide your
- own (usually in `src/config/common/config.js`):
+Declare this module types in your `src/whook.d.ts` type
+ definitions:
+```diff
++ import type { WhookVersionsConfig } from '@whook/versions';
+
+declare module '@whook/whook' {
+
+  // ...
+
+  export interface WhookConfigs
+-    extends WhookBaseConfigs {}
++    extends WhookBaseConfigs, WhookVersionsConfig {}
+
+  // ...
+
+}
+```
+
+And add the errors descriptors or provide your
+ own and configure the module (usually in
+ `src/config/common/config.js`):
 ```diff
 import { DEFAULT_ERRORS_DESCRIPTORS } from '@whook/http-router';
-+ import {
-+   VERSIONS_ERRORS_DESCRIPTORS,
-+   WhookVersionsConfig
-+ } from '@whook/versions';
++ import { VERSIONS_ERRORS_DESCRIPTORS } from '@whook/versions';
+import type { WhookConfigs } from '@whook/whook';
 
 // ...
 
@@ -55,11 +72,7 @@ import { DEFAULT_ERRORS_DESCRIPTORS } from '@whook/http-router';
 +   },
 + ];
 
-export type AppConfigs = WhookConfigs &
-+  WhookVersionsConfig &
-  APIConfig;
-
-const CONFIG: AppConfigs = {
+const CONFIG: WhookConfigs = {
   // ...
 -   ERRORS_DESCRIPTORS: DEFAULT_ERRORS_DESCRIPTORS,
 +   ERRORS_DESCRIPTORS: {

--- a/packages/whook/src/index.ts
+++ b/packages/whook/src/index.ts
@@ -76,6 +76,7 @@ import type {
   WhookAPIOperationAddition,
   WhookAPIOperationConfig,
   WhookAPIOperation,
+  WhookBaseAPIHandlerDefinition,
   WhookAPIHandlerDefinition,
   WhookAPIParameterDefinition,
   WhookAPISchemaDefinition,
@@ -129,6 +130,7 @@ export type {
   WhookAPIDefinitions,
   WhookAPIOperationAddition,
   WhookAPIOperation,
+  WhookBaseAPIHandlerDefinition,
   WhookAPIHandlerDefinition,
   WhookAPIParameterDefinition,
   WhookAPISchemaDefinition,
@@ -210,9 +212,11 @@ export {
   lowerCaseHeaders,
 };
 
-export type WhookEnv = HTTPServerEnv & BaseURLEnv & HostEnv & PortEnv;
+export type WhookBaseEnv = HTTPServerEnv & BaseURLEnv & HostEnv & PortEnv;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WhookEnv extends WhookBaseEnv {}
 
-export type WhookConfigs = ProcessServiceConfig &
+export type WhookBaseConfigs = ProcessServiceConfig &
   HTTPRouterConfig &
   ErrorHandlerConfig &
   HTTPServerConfig &
@@ -226,6 +230,8 @@ export type WhookConfigs = ProcessServiceConfig &
     CONFIG: WhookConfig;
   } & ObfuscatorConfig &
   WhookAPIDefinitionsConfig;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WhookConfigs extends WhookBaseConfigs {}
 
 /* Architecture Note #1: Server run
 Whook exposes a `runServer` function to programmatically spawn

--- a/packages/whook/src/services/API_DEFINITIONS.ts
+++ b/packages/whook/src/services/API_DEFINITIONS.ts
@@ -48,73 +48,81 @@ export type WhookAPIDefinitions = {
   components: OpenAPIV3.ComponentsObject;
 };
 
-export type WhookAPIOperationConfig = {
+export interface WhookAPIOperationConfig {
   disabled?: boolean;
-};
+}
 
-export type WhookAPIOperationAddition<
-  T extends Record<string, unknown> = Record<string, never>,
-> = {
+export interface WhookAPIOperationAddition<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
   operationId: OpenAPIV3.OperationObject['operationId'];
   'x-whook'?: WhookAPIOperationConfig & T;
-};
+}
 
 export type WhookAPIOperation<
   T extends Record<string, unknown> = Record<string, unknown>,
 > = OpenAPIV3.OperationObject & WhookAPIOperationAddition<T>;
 
-export type WhookAPIHandlerDefinition<
+export interface WhookBaseAPIHandlerDefinition<
   T extends Record<string, unknown> = Record<string, unknown>,
   U extends {
     [K in keyof U]: K extends `x-${string}` ? Record<string, unknown> : never;
   } = unknown,
-> = {
+> {
   path: string;
   method: string;
   operation: WhookAPIOperation<T> & U;
-};
+}
 
-export type WhookAPISchemaDefinition<
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WhookAPIHandlerDefinition<
+  T extends Record<string, unknown> = Record<string, unknown>,
+  U extends {
+    [K in keyof U]: K extends `x-${string}` ? Record<string, unknown> : never;
+  } = unknown,
+> extends WhookBaseAPIHandlerDefinition<T, U> {}
+
+export interface WhookAPISchemaDefinition<
   T extends JsonValue | OpenAPIV3.ReferenceObject | void | unknown = unknown,
-> = {
+> {
   name: string;
   schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject;
   example?: T;
   examples?: Record<string, T>;
-};
+}
 
-export type WhookAPIParameterDefinition<
+export interface WhookAPIParameterDefinition<
   T extends JsonValue | OpenAPIV3.ReferenceObject | void | unknown = unknown,
-> = {
+> {
   name: string;
   parameter: OpenAPIV3.ParameterObject;
   example?: T;
   examples?: Record<string, T>;
-};
+}
 
-export type WhookAPIExampleDefinition<
+export interface WhookAPIExampleDefinition<
   T extends JsonValue | OpenAPIV3.ReferenceObject,
-> = {
+> {
   name: string;
   value: T;
-};
+}
 
-export type WhookAPIHeaderDefinition = {
+export interface WhookAPIHeaderDefinition {
   name: string;
   header: OpenAPIV3.HeaderObject | OpenAPIV3.ReferenceObject;
-};
+}
 
-export type WhookAPIResponseDefinition = {
+export interface WhookAPIResponseDefinition {
   name: string;
   response: OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject;
-};
+}
 
-export type WhookAPIRequestBodyDefinition = {
+export interface WhookAPIRequestBodyDefinition {
   name: string;
   requestBody: OpenAPIV3.RequestBodyObject | OpenAPIV3.ReferenceObject;
-};
+}
 
-export type WhookAPIHandlerModule = {
+export interface WhookAPIHandlerModule {
   [name: string]:
     | WhookAPISchemaDefinition<never>
     | WhookAPIParameterDefinition<never>
@@ -123,7 +131,7 @@ export type WhookAPIHandlerModule = {
     | WhookAPIRequestBodyDefinition
     | WhookAPIHandlerDefinition;
   definition: WhookAPIHandlerDefinition;
-};
+}
 
 export default name('API_DEFINITIONS', autoService(initAPIDefinitions));
 


### PR DESCRIPTION
Instead of relying on new types, this PR allow users to rely on types overriding for their endpoints.
That way, we can override Whook's types without having to change their names, especially in the various generators of code.