### PR TITLE
chore(ajv): fix ajv settings to avoid type coercition

### DIFF
--- a/packages/whook-aws-lambda/src/wrappers/awsHTTPLambda.ts
+++ b/packages/whook-aws-lambda/src/wrappers/awsHTTPLambda.ts
@@ -166,8 +166,6 @@ async function initWrapHandlerForConsumerLambda<S extends WhookHandler>({
       warn: (...args: string[]) => log('warning', ...args),
       error: (...args: string[]) => log('error', ...args),
     },
-    useDefaults: true,
-    coerceTypes: true,
   });
   addAJVFormats.default(ajv);
   const ammendedParameters = extractOperationSecurityParameters(

--- a/packages/whook-gcp-functions/src/wrappers/wrapHandlerForGoogleHTTPFunction.ts
+++ b/packages/whook-gcp-functions/src/wrappers/wrapHandlerForGoogleHTTPFunction.ts
@@ -144,8 +144,6 @@ async function initWrapHandlerForGoogleHTTPFunction<S extends WhookHandler>({
       warn: (...args: string[]) => log?.('warning', ...args),
       error: (...args: string[]) => log?.('error', ...args),
     },
-    useDefaults: true,
-    coerceTypes: true,
   });
   addAJVFormats.default(ajv);
   const ammendedParameters = extractOperationSecurityParameters(


### PR DESCRIPTION
Type coercition is no longer necessary since parameters casting is done everywhere (see https://github.com/nfroidure/whook/blob/5c171f7d214529bc2eb641c2ae87321174f51824/packages/whook-aws-lambda/src/wrappers/awsHTTPLambda.ts#L348)
