### PR TITLE
feat(swaggerUI): add displayOperationId option in swaggerUI

### DIFF
--- a/packages/whook-swagger-ui/src/index.ts
+++ b/packages/whook-swagger-ui/src/index.ts
@@ -102,7 +102,8 @@ window.onload = function() {
         ? `, {"name":"Private API","url":"${
             publicSwaggerURL +
             '?access_token=' +
-            encodeURIComponent(DEV_ACCESS_TOKEN)
+            encodeURIComponent(DEV_ACCESS_TOKEN) +
+            '&displayOperationId=true'
           }"}`
         : ''
     }],


### PR DESCRIPTION
Fixes the `displayOperationId` missing from swaggerUI docs.