### PR TITLE
fix(@whook/create): avoid defaulting to a known secret

### DIFF
--- a/packages/whook-create/src/index.ts
+++ b/packages/whook-create/src/index.ts
@@ -7,7 +7,7 @@ import debug from 'debug';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as inquirer from '@inquirer/prompts';
-import { initLog, initLock, initDelay } from 'common-services';
+import { initLog, initLock, initDelay, initRandomBytes } from 'common-services';
 import initAuthor from './services/author.js';
 import initProject from './services/project.js';
 import initCreateWhook from './services/createWhook.js';
@@ -52,6 +52,7 @@ export async function runCreateWhook(): Promise<void> {
     $.register(initLog);
     $.register(initLock);
     $.register(initDelay);
+    $.register(initRandomBytes);
     $.register(initAuthor);
     $.register(initProject);
     $.register(initCreateWhook);

--- a/packages/whook-create/src/services/__snapshots__/createWhook.test.ts.snap
+++ b/packages/whook-create/src/services/__snapshots__/createWhook.test.ts.snap
@@ -50,22 +50,6 @@ Wayne Campbell
 ",
     ],
     [
-      "/home/whoiam/projects/yolo/.env.app.local",
-      "# Loaded when APP_ENV=local
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
-      "/home/whoiam/projects/yolo/.env.app.production",
-      "# Loaded when APP_ENV=production
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
       "/home/whoiam/projects/yolo/.env.node.development",
       "# Loaded when NODE_ENV=development
 
@@ -240,6 +224,22 @@ DEV_MODE=1
     [
       "/home/whoiam/projects/yolo/LICENSE",
       "Copyright Wayne Campbell, all rights reserved.",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.local",
+      "# Loaded when APP_ENV=local
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.production",
+      "# Loaded when APP_ENV=production
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
     ],
     [
       "/home/whoiam/projects/yolo/.gitignore",
@@ -362,22 +362,6 @@ Wayne Campbell
 ",
     ],
     [
-      "/home/whoiam/projects/yolo/.env.app.local",
-      "# Loaded when APP_ENV=local
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
-      "/home/whoiam/projects/yolo/.env.app.production",
-      "# Loaded when APP_ENV=production
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
       "/home/whoiam/projects/yolo/.env.node.development",
       "# Loaded when NODE_ENV=development
 
@@ -554,6 +538,22 @@ DEV_MODE=1
       "Copyright Wayne Campbell, all rights reserved.",
     ],
     [
+      "/home/whoiam/projects/yolo/.env.app.local",
+      "# Loaded when APP_ENV=local
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.production",
+      "# Loaded when APP_ENV=production
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
       "/home/whoiam/projects/yolo/.gitignore",
       "node_modules
 
@@ -561,6 +561,14 @@ DEV_MODE=1
 builds/
 .env*
 ",
+    ],
+  ],
+  "randomBytesCalls": [
+    [
+      16,
+    ],
+    [
+      16,
     ],
   ],
   "readFileCalls": [
@@ -712,22 +720,6 @@ Wayne Campbell
 ",
     ],
     [
-      "/home/whoiam/projects/yolo/.env.app.local",
-      "# Loaded when APP_ENV=local
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
-      "/home/whoiam/projects/yolo/.env.app.production",
-      "# Loaded when APP_ENV=production
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
       "/home/whoiam/projects/yolo/.env.node.development",
       "# Loaded when NODE_ENV=development
 
@@ -902,6 +894,30 @@ DEV_MODE=1
     [
       "/home/whoiam/projects/yolo/LICENSE",
       "Copyright Wayne Campbell, all rights reserved.",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.local",
+      "# Loaded when APP_ENV=local
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.production",
+      "# Loaded when APP_ENV=production
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+  ],
+  "randomBytesCalls": [
+    [
+      16,
+    ],
+    [
+      16,
     ],
   ],
   "readFileCalls": [
@@ -1045,22 +1061,6 @@ Wayne Campbell
 ",
     ],
     [
-      "/home/whoiam/projects/yolo/.env.app.local",
-      "# Loaded when APP_ENV=local
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
-      "/home/whoiam/projects/yolo/.env.app.production",
-      "# Loaded when APP_ENV=production
-
-# For JWT signing
-JWT_SECRET=oudelali
-",
-    ],
-    [
       "/home/whoiam/projects/yolo/.env.node.development",
       "# Loaded when NODE_ENV=development
 
@@ -1237,6 +1237,22 @@ DEV_MODE=1
       "Copyright Wayne Campbell, all rights reserved.",
     ],
     [
+      "/home/whoiam/projects/yolo/.env.app.local",
+      "# Loaded when APP_ENV=local
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
+      "/home/whoiam/projects/yolo/.env.app.production",
+      "# Loaded when APP_ENV=production
+
+# For JWT signing
+JWT_SECRET=615f72616e646f6d5f73657175656e6365
+",
+    ],
+    [
       "/home/whoiam/projects/yolo/.gitignore",
       "node_modules
 
@@ -1244,6 +1260,14 @@ DEV_MODE=1
 builds/
 .env*
 ",
+    ],
+  ],
+  "randomBytesCalls": [
+    [
+      16,
+    ],
+    [
+      16,
     ],
   ],
   "readFileCalls": [

--- a/packages/whook-create/src/services/createWhook.test.ts
+++ b/packages/whook-create/src/services/createWhook.test.ts
@@ -3,7 +3,7 @@ import { describe, test, beforeEach, jest, expect } from '@jest/globals';
 import initCreateWhook from './createWhook.js';
 import { YError } from 'yerror';
 import { readFileSync } from 'node:fs';
-import { type LogService } from 'common-services';
+import { type RandomBytesService, type LogService } from 'common-services';
 import { type PathLike } from 'fs-extra';
 
 const _packageJSON = JSON.parse(
@@ -69,6 +69,7 @@ describe('initCreateWhook', () => {
     start: jest.fn<any>(),
     stopAndPersist: jest.fn<any>(),
   };
+  const randomBytes = jest.fn<RandomBytesService>();
   const log = jest.fn<LogService>();
 
   beforeEach(() => {
@@ -78,6 +79,7 @@ describe('initCreateWhook', () => {
     readdir.mockReset();
     exec.mockReset();
     copy.mockReset();
+    randomBytes.mockReset();
     log.mockReset();
     ora.mockReset();
     ora.mockReturnValue(oraInstance);
@@ -100,6 +102,7 @@ describe('initCreateWhook', () => {
   });
 
   test('should work', async () => {
+    randomBytes.mockResolvedValue(Buffer.from('a_random_sequence'));
     readdir.mockResolvedValueOnce(['local', 'production']);
     copy.mockImplementationOnce(
       (
@@ -157,6 +160,7 @@ describe('initCreateWhook', () => {
       copy,
       axios: axios as any,
       ora: ora as any,
+      randomBytes,
       log,
     });
 
@@ -312,11 +316,13 @@ describe('initCreateWhook', () => {
       oraStartCalls: oraInstance.start.mock.calls,
       oraStopAndPersistCalls: oraInstance.stopAndPersist.mock.calls,
       logCalls: log.mock.calls.filter(([type]) => !type.endsWith('stack')),
+      randomBytesCalls: randomBytes.mock.calls,
       readdirCalls: readFile.mock.calls,
     }).toMatchSnapshot();
   });
 
   test('should handle network issues', async () => {
+    randomBytes.mockResolvedValue(Buffer.from('a_random_sequence'));
     readdir.mockResolvedValueOnce(['local', 'production']);
     copy.mockImplementationOnce(
       (
@@ -372,6 +378,7 @@ describe('initCreateWhook', () => {
       copy,
       axios: axios as any,
       ora: ora as any,
+      randomBytes,
       log,
     });
 
@@ -527,11 +534,13 @@ describe('initCreateWhook', () => {
       oraStartCalls: oraInstance.start.mock.calls,
       oraStopAndPersistCalls: oraInstance.stopAndPersist.mock.calls,
       logCalls: log.mock.calls.filter(([type]) => !type.endsWith('stack')),
+      randomBytesCalls: randomBytes.mock.calls,
       readdirCalls: readFile.mock.calls,
     }).toMatchSnapshot();
   });
 
   test('should handle git initialization problems', async () => {
+    randomBytes.mockResolvedValue(Buffer.from('a_random_sequence'));
     readdir.mockResolvedValueOnce(['local', 'production']);
     copy.mockResolvedValueOnce(new YError('E_ACCESS'));
     axios.mockResolvedValueOnce({
@@ -567,6 +576,7 @@ describe('initCreateWhook', () => {
       copy,
       axios: axios as any,
       ora: ora as any,
+      randomBytes,
       log,
     });
 
@@ -722,11 +732,13 @@ describe('initCreateWhook', () => {
       oraStartCalls: oraInstance.start.mock.calls,
       oraStopAndPersistCalls: oraInstance.stopAndPersist.mock.calls,
       logCalls: log.mock.calls.filter(([type]) => !type.endsWith('stack')),
+      randomBytesCalls: randomBytes.mock.calls,
       readdirCalls: readFile.mock.calls,
     }).toMatchSnapshot();
   });
 
   test('should fail with access problems', async () => {
+    randomBytes.mockResolvedValue(Buffer.from('a_random_sequence'));
     readdir.mockResolvedValueOnce(['local', 'production']);
     copy.mockRejectedValueOnce(new YError('E_ACCESS'));
     axios.mockResolvedValueOnce({
@@ -763,6 +775,7 @@ describe('initCreateWhook', () => {
         copy,
         axios: axios as any,
         ora: ora as any,
+        randomBytes,
         log,
       });
 

--- a/packages/whook-create/src/services/createWhook.ts
+++ b/packages/whook-create/src/services/createWhook.ts
@@ -6,7 +6,7 @@ import { join, relative } from 'node:path';
 import _axios from 'axios';
 import _ora from 'ora';
 import { printStackTrace, YError } from 'yerror';
-import { type LogService } from 'common-services';
+import { type LogService, type RandomBytesService } from 'common-services';
 import { type ProjectService } from './project.js';
 import { type AuthorService } from './author.js';
 
@@ -20,6 +20,7 @@ export type CreateWhookService = () => Promise<void>;
 export default autoService(async function initCreateWhook({
   CWD,
   SOURCE_DIR,
+  randomBytes,
   author,
   project,
   outputFile = _outputFile,
@@ -33,6 +34,7 @@ export default autoService(async function initCreateWhook({
 }: {
   CWD: string;
   SOURCE_DIR: string;
+  randomBytes: RandomBytesService;
   author: AuthorService;
   project: ProjectService;
   outputFile: typeof _outputFile;
@@ -136,7 +138,7 @@ ${author.name}
         ),
       ),
       ...(await readdir(join(SOURCE_DIR, 'src', 'config'))).map(
-        (environment) =>
+        async (environment) =>
           environment === 'common'
             ? Promise.resolve()
             : outputFile(
@@ -144,7 +146,7 @@ ${author.name}
                 `# Loaded when APP_ENV=${environment}
 
 # For JWT signing
-JWT_SECRET=oudelali
+JWT_SECRET=${(await randomBytes(16)).toString('hex')}
 `,
               ),
       ),


### PR DESCRIPTION
Create a random secret when generating a new project to default to secure JWT.
